### PR TITLE
Import Multiple Selected Not Working

### DIFF
--- a/fields/field.association.php
+++ b/fields/field.association.php
@@ -743,8 +743,8 @@ class FieldAssociation extends Field implements ExportableField, ImportableField
     public function getImportModes()
     {
         return array(
-            'getValue' =>       ImportableField::STRING_VALUE,
-            'getPostdata' =>    ImportableField::ARRAY_VALUE
+            'getPostdata' =>    ImportableField::ARRAY_VALUE,
+            'getValue' =>       ImportableField::STRING_VALUE
         );
     }
 
@@ -772,7 +772,7 @@ class FieldAssociation extends Field implements ExportableField, ImportableField
                 }
             }
 
-            return $this->processRawFieldData($data, $status, $message, true, $entry_id);
+            return $data;
         }
 
         return null;


### PR DESCRIPTION
I've been trying to import some associations from an Older Symphony, whenever there were multiple relations it was just appending the entry id's to each other, rather than treating them separately. I'm not sure if the default mode should be `ImportableField::ARRAY_VALUE` however this was the only way I was able to import from XML Importer. Also the array should return the data as expected by `processRawFieldData` not execute it, otherwise it tries to insert `Array` into the database instead of the entry ID.