### PR TITLE
mySQL 5.7 compatibility, add sortfield in distinct select

### DIFF
--- a/extension.meta.xml
+++ b/extension.meta.xml
@@ -13,6 +13,10 @@
 		</author>
 	</authors>
 	<releases>
+		<release version="1.1.0" date="2016-02-22" min="2.5">
+			- Added new `AssociationFiltering` delegate allowing extension to filter results
+			- Fix MySQL 5.7 Distinct, order by error when in strict mode
+		</release>
 		<release version="1.0.1" date="2015-07-21" min="2.5">
 			- Removed association count from index for single select fields
 		</release>

--- a/fields/field.association.php
+++ b/fields/field.association.php
@@ -121,8 +121,29 @@ class FieldAssociation extends Field implements ExportableField, ImportableField
                 );
 
                 if ($limit > 0) {
+
+                    $where = '';
+                    $joins = '';
+
+                    /**
+                     * Allow the results to be modified using adjust publish filtering functionality on the core
+                     *
+                     * @delegate AssociationFiltering
+                     * @since Symphony 1.1.0
+                     * @param string $context
+                     * '/publish/'
+                     * @param array $options
+                     *  An array which should contain the section id
+                     *  and the joins and where clauses by reference both passed by reference
+                     */
+                    Symphony::ExtensionManager()->notifyMembers('AssociationFiltering', '/publish/', array(
+                        'section-id' => $section->get('id'),
+                        'joins' => &$joins,
+                        'where' => &$where
+                    ));
+
                     EntryManager::setFetchSorting($section->getSortingField(), $section->getSortingOrder());
-                    $entries = EntryManager::fetch(null, $section->get('id'), $limit, 0, null, null, false, false);
+                    $entries = EntryManager::fetch(null, $section->get('id'), $limit, 0, $where, $joins, false, false);
                     foreach ($entries as $entry) {
                         $results[] = (int) $entry['id'];
                     }

--- a/fields/field.association.php
+++ b/fields/field.association.php
@@ -102,7 +102,7 @@ class FieldAssociation extends Field implements ExportableField, ImportableField
 
         // find the sections of the related fields
         $sections = Symphony::Database()->fetch(
-            "SELECT DISTINCT (s.id), f.id as `field_id`
+            "SELECT DISTINCT (s.id), f.id as `field_id`, s.sortorder 
              FROM `tbl_sections` AS `s`
              LEFT JOIN `tbl_fields` AS `f` ON `s`.id = `f`.parent_section
              WHERE `f`.id IN ('" . implode("','", $this->get('related_field_id')) . "')


### PR DESCRIPTION
It seems like mySQL 5.7.10 throws errors everytime there is a distinct with a sort clause where the sort is not included in the select, this just adds the sort order within the query select statement.