### PR TITLE
chore: Remove unnecessary interface includes

### DIFF
--- a/fields/field.association.php
+++ b/fields/field.association.php
@@ -164,6 +164,9 @@ class FieldAssociation extends Field implements ExportableField, ImportableField
                 if (!is_null($entry_id) && isset($group['values'][$entry_id])) {
                     unset($group['values'][$entry_id]);
                 }
+
+                asort($group['values']);
+
                 $values[] = $group;
             }
         }

--- a/fields/field.association.php
+++ b/fields/field.association.php
@@ -4,9 +4,6 @@ if (!defined('__IN_SYMPHONY__')) {
     die('<h2>Symphony Error</h2><p>You cannot directly access this file</p>');
 }
 
-require_once FACE . '/interface.exportablefield.php';
-require_once FACE . '/interface.importablefield.php';
-
 class FieldAssociation extends Field implements ExportableField, ImportableField
 {
     private static $cache = array();


### PR DESCRIPTION
Since Symphony uses a composer classmap autoloader for all classes in `/lib` (see, [composer.json#L23](https://github.com/symphonycms/symphonycms/blob/68f44f0c36ad3345068676bfb8a61c2e6a2e51f4/composer.json#L23)), this commit removes the redundant require_once statements. Doing so avoids code breaking if `interface.exportablefield.php`, or `interface.importablefield.php` are renamed or they are no longer in `FACE`.